### PR TITLE
Bugfix: "New Highscore" Message

### DIFF
--- a/pages/index.js
+++ b/pages/index.js
@@ -51,6 +51,7 @@ export default function SnakeGame () {
     setApple(generateApplePosition())
     setVelocity({ dx: 0, dy: -1 })
     setRunning(true)
+    setNewHighscore(false)
     setCountDown(3)
   }
 
@@ -58,7 +59,7 @@ export default function SnakeGame () {
   const gameOver = () => {
     if (score > highscore) {
       setHighscore(score)
-      localStorage.setItem('highscore', highscore)
+      localStorage.setItem('highscore', score)
       setNewHighscore(true)
     }
     setIsLost(true)
@@ -186,7 +187,7 @@ export default function SnakeGame () {
         <section>
           <div className='score'>
             <p><FontAwesomeIcon icon={['fas', 'star']} />Score: {score}</p>
-            <p><FontAwesomeIcon icon={['fas', 'trophy']} />Highscore: {highscore}</p>
+            <p><FontAwesomeIcon icon={['fas', 'trophy']} />Highscore: {highscore > score ? highscore : score}</p>
           </div>
           { (!isLost && countDown > 0) ?
             <button onClick={startGame}>{ countDown === 4 ? 'Start Game' : countDown}</button> :


### PR DESCRIPTION
### Bug Description:
The "new highscore" message occurs on every "game over" screen, once the current highscore is broken for the first time

### Bug Preview:
<img width="1321" alt="Screenshot 2020-07-29 at 14 04 20" src="https://user-images.githubusercontent.com/5675238/88797945-68202400-d1a4-11ea-9353-5cda408f4c70.png">

### Fix:
To fix this, the newHighscore state is set to false in the startGame function.